### PR TITLE
Use state pattern for race

### DIFF
--- a/src/Race/AbortedState.ts
+++ b/src/Race/AbortedState.ts
@@ -1,0 +1,11 @@
+import { WebhookEditMessageOptions } from "discord.js";
+import { RaceState } from "./RaceState";
+
+export class AbortedState extends RaceState {
+  renderPublicMessage(): WebhookEditMessageOptions {
+    return {
+      content: "Race aborted, no participants",
+      components: [],
+    };
+  }
+}

--- a/src/Race/AbortedState.ts
+++ b/src/Race/AbortedState.ts
@@ -2,6 +2,10 @@ import { WebhookEditMessageOptions } from "discord.js";
 import { RaceState } from "./RaceState";
 
 export class AbortedState extends RaceState {
+  onEnter() {
+    this.race.cleanup();
+    this.race.onComplete();
+  }
   renderPublicMessage(): WebhookEditMessageOptions {
     return {
       content: "Race aborted, no participants",

--- a/src/Race/CompleteState.ts
+++ b/src/Race/CompleteState.ts
@@ -1,0 +1,12 @@
+import { WebhookEditMessageOptions } from "discord.js";
+import { RaceState } from "./RaceState";
+
+export class CompleteState extends RaceState {
+  renderPublicMessage(): WebhookEditMessageOptions {
+    return {
+      content:
+        "```" + this.race.string + "```\n" + this.race.renderParticipantList(),
+      components: [],
+    };
+  }
+}

--- a/src/Race/CountdownState.ts
+++ b/src/Race/CountdownState.ts
@@ -60,14 +60,7 @@ export class CountdownState extends RaceState {
 
   start() {
     const race = this.race;
-    if (race.hasNoParticipants) {
-      race.setState(AbortedState);
-      race.cleanup();
-      race.onComplete();
-      return;
-    }
-
-    race.startTime = new Date();
+    if (race.hasNoParticipants) return race.setState(AbortedState);
 
     race.setState(InProgressState);
   }

--- a/src/Race/CountdownState.ts
+++ b/src/Race/CountdownState.ts
@@ -1,0 +1,74 @@
+import {
+  ButtonInteraction,
+  User,
+  MessageActionRow,
+  MessageButton,
+  WebhookEditMessageOptions,
+  CacheType,
+} from "discord.js";
+import { RaceState } from "./RaceState";
+import { AbortedState } from "./AbortedState";
+import { InProgressState } from "./InProgressState";
+
+export class CountdownState extends RaceState {
+  onEnter(): void {
+    this.race.interaction.reply({
+      ephemeral: this.race.debugMode,
+      ...this.renderPublicMessage(),
+    });
+  }
+
+  tick(): void {
+    const race = this.race;
+    if (race.shouldBroadcastRaceCountdown) {
+      race.participants.forEach((p) => this.sendCountdownMessage(p));
+    }
+
+    race.remainingRaceCountdownTicks--;
+
+    if (!race.hasRemainingRaceCountdownTicks) {
+      this.start();
+    }
+  }
+
+  async sendCountdownMessage(participant: User) {
+    participant.send(this.race.remainingRaceCountdownTicks + "...");
+  }
+
+  renderPublicMessage(): WebhookEditMessageOptions {
+    const buttonRow = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setCustomId("JOIN_RACE")
+        .setLabel("Join")
+        .setStyle("PRIMARY")
+    );
+
+    const countdown = `Race starting in ${this.race.remainingRaceCountdownTicks} seconds...`;
+
+    return {
+      content: countdown + "\n" + this.race.renderParticipantList(),
+      components: [buttonRow],
+    };
+  }
+
+  consumeButtonInteraction(interaction: ButtonInteraction<CacheType>): void {
+    let buttonId = interaction.customId;
+    if (this.race.isJoinRaceButton(buttonId)) {
+      this.race.addParticipant(interaction);
+    }
+  }
+
+  start() {
+    const race = this.race;
+    if (race.hasNoParticipants) {
+      race.setState(AbortedState);
+      race.cleanup();
+      race.onComplete();
+      return;
+    }
+
+    race.startTime = new Date();
+
+    race.setState(InProgressState);
+  }
+}

--- a/src/Race/InProgressState.ts
+++ b/src/Race/InProgressState.ts
@@ -1,0 +1,39 @@
+import { Message, WebhookEditMessageOptions } from "discord.js";
+import { RaceState } from "./RaceState";
+
+export class InProgressState extends RaceState {
+  onEnter(): void {
+    this.race.participants.forEach((p) => this.race.sendStartMessage(p));
+  }
+
+  tick(): void {
+    this.race.remainingAutocompleteTicks--;
+    if (!this.race.hasRemainingAutocompleteTicks) {
+      this.race.autocomplete();
+    }
+  }
+
+  renderPublicMessage(): WebhookEditMessageOptions {
+    return {
+      content:
+        "Race in progress\n" +
+        this.race.renderParticipantList() +
+        "\nRace ending in " +
+        this.race.remainingAutocompleteTicks +
+        " seconds",
+      components: [],
+    };
+  }
+
+  consumeMessage(message: Message): void {
+    let inputText = message.content;
+    if (!this.race.isInputTextAccurate(inputText)) {
+      message.author.send("Oops, something wasn't quite right.");
+      return;
+    }
+
+    message.author.send("Completed");
+    this.race.markParticipantAsComplete(message.author);
+    this.race.checkCompletion();
+  }
+}

--- a/src/Race/InProgressState.ts
+++ b/src/Race/InProgressState.ts
@@ -3,6 +3,7 @@ import { RaceState } from "./RaceState";
 
 export class InProgressState extends RaceState {
   onEnter(): void {
+    this.race.startTime = new Date();
     this.race.participants.forEach((p) => this.race.sendStartMessage(p));
   }
 

--- a/src/Race/InProgressState.ts
+++ b/src/Race/InProgressState.ts
@@ -1,15 +1,22 @@
 import { Message, WebhookEditMessageOptions } from "discord.js";
 import { RaceState } from "./RaceState";
 
+const AUTOCOMPLETE_TICKS = 30;
+const DEBUG_AUTOCOMPLETE_TICKS = 10;
+
 export class InProgressState extends RaceState {
+  remainingTicks: number = 0;
   onEnter(): void {
+    this.remainingTicks = this.race.debugMode
+      ? DEBUG_AUTOCOMPLETE_TICKS
+      : AUTOCOMPLETE_TICKS;
     this.race.startTime = new Date();
     this.race.participants.forEach((p) => this.race.sendStartMessage(p));
   }
 
   tick(): void {
-    this.race.remainingAutocompleteTicks--;
-    if (!this.race.hasRemainingAutocompleteTicks) {
+    this.remainingTicks--;
+    if (this.remainingTicks <= 0) {
       this.race.autocomplete();
     }
   }
@@ -20,7 +27,7 @@ export class InProgressState extends RaceState {
         "Race in progress\n" +
         this.race.renderParticipantList() +
         "\nRace ending in " +
-        this.race.remainingAutocompleteTicks +
+        this.remainingTicks +
         " seconds",
       components: [],
     };

--- a/src/Race/InitializedState.ts
+++ b/src/Race/InitializedState.ts
@@ -1,0 +1,3 @@
+import { RaceState } from "./RaceState";
+
+export class InitializedState extends RaceState {}

--- a/src/Race/Race.ts
+++ b/src/Race/Race.ts
@@ -13,13 +13,7 @@ import { InProgressState } from "./InProgressState";
 import { CompleteState } from "./CompleteState";
 import { RaceState } from "./RaceState";
 
-const STARTING_RACE_COUNTDOWN_TICKS = 20;
-const STARTING_RACE_COUNTDOWN_BROADCAST_THRESHOLD = 5;
-const AUTOCOMPLETE_TICKS = 30;
 const TICK_INTERVAL_MS = 1000;
-
-const DEBUG_STARTING_RACE_COUNTDOWN_TICKS = 5;
-const DEBUG_AUTOCOMPLETE_TICKS = 5;
 
 interface onCompleteCallback {
   (): void;
@@ -40,8 +34,6 @@ export default class Race {
   string: string;
   interaction: BaseCommandInteraction;
   participants: User[];
-  remainingRaceCountdownTicks: number;
-  remainingAutocompleteTicks: number;
   startTime: Date | null;
   completionTimes: CompletionTimes;
   onComplete: onCompleteCallback;
@@ -55,12 +47,6 @@ export default class Race {
     this.debugMode = options.debugMode || false;
     this.string = this.debugMode ? "test string" : this.selectQuote();
     this.participants = [];
-    this.remainingRaceCountdownTicks = this.debugMode
-      ? DEBUG_STARTING_RACE_COUNTDOWN_TICKS
-      : STARTING_RACE_COUNTDOWN_TICKS;
-    this.remainingAutocompleteTicks = this.debugMode
-      ? DEBUG_STARTING_RACE_COUNTDOWN_TICKS + DEBUG_AUTOCOMPLETE_TICKS
-      : STARTING_RACE_COUNTDOWN_TICKS + AUTOCOMPLETE_TICKS;
     this.startTime = null;
     this.completionTimes = {};
     this.tickInterval = null;
@@ -131,6 +117,7 @@ export default class Race {
     if (!this.startTime) {
       return;
     }
+    console.log(this.startTime, new Date());
     const completionTime = new Date().getTime() - this.startTime.getTime();
     this.completionTimes[participant.id] = completionTime;
   }
@@ -172,18 +159,6 @@ export default class Race {
   }
 
   // CONDITIONALS
-  get hasRemainingRaceCountdownTicks() {
-    return this.remainingRaceCountdownTicks > 0;
-  }
-  get hasRemainingAutocompleteTicks() {
-    return this.remainingAutocompleteTicks > 0;
-  }
-  get shouldBroadcastRaceCountdown() {
-    return (
-      this.remainingRaceCountdownTicks <=
-      STARTING_RACE_COUNTDOWN_BROADCAST_THRESHOLD
-    );
-  }
   get hasNoParticipants() {
     return this.participants.length === 0;
   }

--- a/src/Race/RaceState.ts
+++ b/src/Race/RaceState.ts
@@ -1,0 +1,22 @@
+import {
+  ButtonInteraction,
+  Message,
+  WebhookEditMessageOptions,
+} from "discord.js";
+import Race from "../Race/Race";
+
+export class RaceState {
+  race: Race;
+  constructor(race: Race) {
+    this.race = race;
+  }
+  onEnter(): void {}
+  tick(): void {}
+  renderPublicMessage(): WebhookEditMessageOptions {
+    return {};
+  }
+  consumeMessage(message: Message) {
+    message.author.send("Race isn't active.");
+  }
+  consumeButtonInteraction(interaction: ButtonInteraction) {}
+}

--- a/src/raceTracker.ts
+++ b/src/raceTracker.ts
@@ -1,5 +1,5 @@
 import { BaseCommandInteraction, Message, ButtonInteraction } from "discord.js";
-import Race from "./Race";
+import Race from "./Race/Race";
 
 class RaceTracker {
   currentRace: Race | null;


### PR DESCRIPTION
Use the state pattern to delegate `ticket`, `renderPublicMessage`, and `consume*` methods. Move state change effects into `onEnter`. 